### PR TITLE
Fix refreshFunction() continuously called on touch/click when no data…

### DIFF
--- a/src/index.tsx
+++ b/src/index.tsx
@@ -138,13 +138,6 @@ export default class InfiniteScroll extends Component<Props, State> {
   }
 
   UNSAFE_componentWillReceiveProps(props: Props) {
-    // do nothing when dataLength and key are unchanged
-    if (
-      this.props.key === props.key &&
-      this.props.dataLength === props.dataLength
-    )
-      return;
-
     this.actionTriggered = false;
     // update state when new data was sent in
     this.setState({


### PR DESCRIPTION
… has been changed

There may be cases when data may not necessarily always need to change.

pullToRefreshThresholdBreached is permanently set to true when no data change in length is detected. Causing refreshFunction() to be called continuously called on touch/click when no data has been changed.